### PR TITLE
Add mandatory version number in manifest

### DIFF
--- a/custom_components/apiEnedis/manifest.json
+++ b/custom_components/apiEnedis/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "myEnedis",
     "name": "myEnedis sensor",
+    "version": "1.1.3.2",
     "documentation": "https://github.com/saniho/apiEnedis/",
     "config_flow": true,
     "requirements": [


### PR DESCRIPTION
Depuis la dernière release d'HA, il est indiqué dans les BC qu'il faut mettre la version dans les manifest des intégrations : https://www.home-assistant.io/blog/2021/03/03/release-20213/#breaking-changes