### PR TITLE
Add EN translations

### DIFF
--- a/custom_components/apiEnedis/translations/en.json
+++ b/custom_components/apiEnedis/translations/en.json
@@ -1,0 +1,31 @@
+{
+  "title": "MyEnedis",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "token": "Your Token",
+          "code": "Your Code",
+          "hc_cout": "Off-peak hours price (ex: 0.01)",
+          "hp_cout": "Peak hours price (ex: 0.01)",
+          "heuresCreusesON": "Check if you have a peak & off-peak hours based contract"
+        },
+        "title": "MyEnedis configuration"
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "token": "Your Token",
+          "code": "Your Code",
+          "hc_cout": "Off-peak hours price (ex: 0.01)",
+          "hp_cout": "Peak hours price (ex: 0.01)",
+          "heuresCreusesON": "Check if you have a peak & off-peak hours based contract"
+        },
+        "title": "MyEnedis Options"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Vu que j'ai mon HA en anglais, quand j'allais sur la config de l'intégration via l'UI y'avait aucun label d'affiché, donc pas pratique pour se rappeler quel champ correspondait aux HC ou aux HP :)