### PR TITLE
Add python checks, prepare for hacs

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,28 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip wheel
+      - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
+                         flake8-comprehensions isort mypy pytest pyupgrade safety
+      # Skipping rules that may be fixed, but would block the flow at this moment
+      - run: bandit --recursive --skip B101,B105,B110,B307,B310,B311 .
+      - run: black --check . || true
+      # Skipping codespell because of french comments
+      # - run: codespell --ignore-words-list="hass"
+      # Ignoring more rules than we should to avoid blocking, and complexity level too high
+      - run: flake8 . --count --ignore E401,F401,W503,F841,E266,E402,E722,C416,B001,B008
+                      --max-complexity=34 --max-line-length=184 --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt || pip install --editable . || true
+      - run: mkdir --parents --verbose .mypy_cache
+      - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
+      - run: pytest . || true
+      #- run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check
+

--- a/.github/workflows/validate-hacs.yml
+++ b/.github/workflows/validate-hacs.yml
@@ -1,0 +1,26 @@
+name: Validate with hassfest
+
+# Note commented because the integration is not ready
+# Run manually
+on:
+  workflow_dispatch:
+  #push:
+  #pull_request:
+  #schedule:
+  #  - cron:  '0 0 * * *'
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+        - uses: "actions/checkout@v2"
+        - uses: "home-assistant/actions/hassfest@master"
+  hacs:
+    name: HACS Action
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - name: HACS Action
+        uses: "hacs/action@main"
+        with:
+          category: "integration"


### PR DESCRIPTION
Une branche sans les modification de code pour éviter les conflits.

Ceci ajoute seulement le "workflow" pour les verifications.

Pour régler la plupart des problèmes, il suffit de faire:
```
pip install black
black .
find . -name '*.py' -exec perl -i -p -e 's/ == None/ is None/g;' {} \;
find . -name '*.py' -exec perl -i -p -e 's/ != None/ is not None/g;' {} \;
find . -name '*.py' -exec perl -i -p -e 's/ == False/ is False/g;' {} \;
```

Ensuite il restera qqs mineurs trucs à ajuster

Je ferme l'autre pull request.
