### PR TITLE
Add pytest configuration to avoid 'warning' about asyncio during tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+asyncio_mode=strict


### PR DESCRIPTION
Le test termine plus propre avec cette petite config.