### PR TITLE
Extend datetime mock to today, and apply to test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       # - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-json
+        exclude: ^(tests/Json/Error/errorContrat.json)$
       - id: mixed-line-ending
       - id: check-builtin-literals
       - id: check-ast

--- a/tests/test_myEnedis.py
+++ b/tests/test_myEnedis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import json
 import logging
+import os
 
 import pytest
 import requests_mock
@@ -10,7 +11,6 @@ import requests_mock
 from custom_components.apiEnedis.myClientEnedis import myClientEnedis
 from custom_components.apiEnedis.sensorEnedis import manageSensorState
 
-import os
 JSON_DIR = os.path.dirname(__file__) + "/Json/"
 
 contractJsonFile = "Contract/contract1.json"
@@ -132,8 +132,10 @@ def test_heures_creuses():
     assert myE.contract.getHeuresCreuses() == dataCompare, "erreur format HC/HP 2"
 
 
-@pytest.mark.usefixtures('patch_datetime_now')
-@pytest.mark.parametrize('patch_datetime_now', [(datetime.datetime(2020,12,9,11,22,00))], indirect=True)
+@pytest.mark.usefixtures("patch_datetime_now")
+@pytest.mark.parametrize(
+    "patch_datetime_now", [(datetime.datetime(2020, 12, 9, 11, 22, 00))], indirect=True
+)
 def test_update_last7days(caplog):
     caplog.set_level(logging.DEBUG)  # Aide au debogue
     myE = myClientEnedis("myToken", "myPDL")
@@ -151,7 +153,7 @@ def test_update_last7days(caplog):
         {"date": "2020-12-03", "niemejour": 7, "value": 33665},
     ]
     data = myE.getLast7Days().getValue()
-    LOGGER.debug("Last7Days Data = %s", data) 
+    LOGGER.debug("Last7Days Data = %s", data)
     assert dataExpected == data
     # assert error == "Error last7Days"
 

--- a/tests/test_myEnedis.py
+++ b/tests/test_myEnedis.py
@@ -154,8 +154,7 @@ def test_update_last7days(caplog):
     ]
     data = myE.getLast7Days().getValue()
     LOGGER.debug("Last7Days Data = %s", data)
-    assert dataExpected == data
-    # assert error == "Error last7Days"
+    assert dataExpected == data, "Error last7Days"
 
 
 def test_update_last_month():


### PR DESCRIPTION
En lien avec #75 - je n'ai pas trouvé le test qui permet de valider la fonctionnalité HC/HP.

J'ai étendu la fonctionnalité pour forcer une date/heure pour un test, en ajoutant datetime.date notamment, et aussi en le rendant configurable pour un test.

J'ai apporté d'autres amélioriations au tests:
- on peut faire `pvtest` dans le répertoire test même,
- l'affichage des messages "logging" est fournie également (en augmentant le niveau pour un test).

Du coup il y a un test qui ne passe pas (car j'ai activé l'assert), mais comme la date est forcée je pense que tu peux le remettre au point.