### PR TITLE
Release script en remplacement de #131

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,45 @@
+---
+name-template: '⚡v$RESOLVED_VERSION '
+tag-template: v$RESOLVED_VERSION
+change-template: '- #$NUMBER $TITLE @$AUTHOR'
+sort-direction: ascending
+categories:
+  - title: 🚀 Fonctionnalités & amélioriations
+    labels:
+      - feature
+      - enhancement
+
+  - title: 🐛 Corrections
+    labels:
+      - fix
+      - bugfix
+      - bug
+
+  - title: 🧰 Maintenance
+    label: chore
+
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+  patch:
+    labels:
+      - patch
+  default: patch
+template: |
+  ## Evolutions
+
+  $CHANGES
+
+  ## ⭐️ Contributeurs
+  $CONTRIBUTORS
+autolabeler:
+  - label: bug
+    branch:
+      - /fix\/.+/
+  - label: enhancement
+    branch:
+      - /feature\/.+/

--- a/.github/scripts/update_hacs_manifest.py
+++ b/.github/scripts/update_hacs_manifest.py
@@ -1,0 +1,57 @@
+#!/bin/env python3
+#
+# Takes --version X.Y.Z or -V X.Y.Z option and sets version in manifest.json.
+# Must be launched from the root of the repository.
+#
+# Modified from : https://raw.githubusercontent.com/bramstroker/homeassistant-powercalc/master/.github/scripts/update_hacs_manifest.py  # noqa: E501
+#
+# MIT License
+#
+# Copyright (c) 2021 Bram Gerritsen
+# Copyright (c) 2022 Mario DE WEERD
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Update the manifest file."""
+import json
+import os
+import sys
+
+
+def update_manifest():
+    """Update the manifest file."""
+    version = "0.0.0"
+    for index, value in enumerate(sys.argv):
+        if value in ["--version", "-V"]:
+            version = sys.argv[index + 1]
+
+    with open(
+        f"{os.getcwd()}/custom_components/apiEnedis/manifest.json"
+    ) as manifestfile:
+        manifest = json.load(manifestfile)
+
+    manifest["version"] = version
+
+    with open(
+        f"{os.getcwd()}/custom_components/apiEnedis/manifest.json", "w"
+    ) as manifestfile:
+        manifestfile.write(json.dumps(manifest, indent=4, sort_keys=True))
+
+
+update_manifest()

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+---
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    name: Update release draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Create Release
+        uses: release-drafter/release-drafter@v5
+        with:
+          disable-releaser: github.ref != 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+---
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release_zip_file:
+    name: Prepare release asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Get version
+        id: version
+        uses: home-assistant/actions/helpers/version@master
+
+      - name: Set version number
+        run: >-
+          python3
+          ${{ github.workspace }}/.github/scripts/update_hacs_manifest.py
+          --version ${{ steps.version.outputs.version }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: \[Bot\] Release - version update ${{ steps.version.outputs.version
+            }}
+          commit_user_name: release
+          commit_user_email: release@nill
+          commit_author: release bot <release>
+      - name: Create zip
+        run: |
+          cd custom_components/apiEnedis
+          zip apiEnedis.zip -r ./
+      - name: Upload zip to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./custom_components/apiEnedis/apiEnedis.zip
+          asset_name: apiEnedis.zip
+          tag: ${{ github.ref }}
+          overwrite: true


### PR DESCRIPTION
Release script en remplacement de #131 .

Certains fichiers doivent être dans main pour que cela fonctionne.
Cela peut être testé en pre-release & tant que ce n'est pas au point, le ZIP peut toujours être supprimé après génération (il faut peut-être le renommer en myEnedis).