### PR TITLE
Make tag move step not blocking, add downloads badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,9 @@ jobs:
       # Move the tag
       - name: Move Release Tag to include updated manifest
         uses: EndBug/latest-tag@latest
+        # Continue anyway if moving the tag failes (protected
+        # branch for instance) - the ZIP will be fine.
+        continue-on-error: true
         with:
           tag-name: ${{ steps.get-ref.outputs.tag }}
         env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # myEnedis
 
 [![HACS Supported](https://img.shields.io/badge/HACS-Supported-green.svg)](https://github.com/custom-components/hacs)
+![](https://img.shields.io/github/downloads/saniho/apiEnedis/latest/total.svg)
 
 **Cette integration est compatible avec la carte :
 https://github.com/saniho/content-card-linky**


### PR DESCRIPTION
Ceci devrait éviter que la "tentative" de bouger le tag dans une branche protégée ne bloque pas la création du zip et la réussite de l'action.

Le contenu du tag ne pointera pas vers le manifest avec la version correspondante, mais ce cera un moindre mal car désormais c'est le zip qui est utilisé pour les installations.