### PR TITLE
Ajout information en cas d'erreur d'écriture

### DIFF
--- a/custom_components/apiEnedis/apiconst.py
+++ b/custom_components/apiEnedis/apiconst.py
@@ -1,0 +1,25 @@
+# Constants for API Json
+
+# Error code - string
+ERROR_CODE = "error_code"
+# Error string - string
+ERROR = "error"
+
+# Note: both of these fields occur - same meaning:
+# Alert user - bool
+ALERT_USER = "alert_user"
+# User alert - bool
+USER_ALERT = "user_alert"
+
+# tag
+TAG = "tag"
+# description - string
+DESCRIPTION = "description"
+
+# Structure with meter reading data
+METER_READING = "meter_reading"
+
+ENEDIS_RETURN = "enedis_return"
+# Fields in "enedis_return"
+ENEDIS_RETURN_ERROR = "error"
+ENEDIS_RETURN_MESSAGE = "message"

--- a/custom_components/apiEnedis/myCall.py
+++ b/custom_components/apiEnedis/myCall.py
@@ -15,6 +15,8 @@ import logging
 import re
 import sys
 
+from . import apiconst as API
+
 _LOGGER = logging.getLogger(__nameMyEnedis__)
 
 # Min and Max Delays for initial call and subsequent calls.
@@ -137,10 +139,10 @@ class myCall:
             try:
                 if not myCall.isAvailable():
                     dataAnswer = {
-                        "error_code": "UNAVAILABLE",
-                        "enedis_return": {
-                            "error": "UNAVAILABLE",
-                            "message": "Indisponible, essayez plus tard",
+                        API.ERROR_CODE: "UNAVAILABLE",
+                        API.ENEDIS_RETURN: {
+                            API.ENEDIS_RETURN_ERROR: "UNAVAILABLE",
+                            API.ENEDIS_RETURN_MESSAGE: "Indisponible, essayez plus tard",
                         },
                     }
                     self.setLastAnswer(dataAnswer)
@@ -185,9 +187,9 @@ class myCall:
                 # a ajouter raison de l'erreur !!!
                 _LOGGER.error(f"{logPrefix}requests.exceptions.Timeout")
                 dataAnswer = {
-                    "enedis_return": {
-                        "error": "UNKERROR_TIMEOUT",
-                        "message": "Timeout",
+                    API.ENEDIS_RETURN: {
+                        API.ENEDIS_RETURN_ERROR: "UNKERROR_TIMEOUT",
+                        API.ENEDIS_RETURN_MESSAGE: "Timeout",
                     }
                 }
                 self.setLastAnswer(dataAnswer)
@@ -216,10 +218,10 @@ class myCall:
                     maxTriesToGo = 0  # Fatal error, do not try again
 
         _LOGGER.debug("Data answer: %r", dataAnswer)
-        # if ( "enedis_return" in dataAnswer.keys() ):
-        #    if ( type( dataAnswer["enedis_return"] ) is dict ):
-        #        if ( "error" in dataAnswer["enedis_return"].keys()):
-        #            if ( dataAnswer["enedis_return"]["error"] == "UNKERROR_TIMEOUT"):
+        # if ( API.ENEDIS_RETURN in dataAnswer.keys() ):
+        #    if ( type( dataAnswer[API.ENEDIS_RETURN] ) is dict ):
+        #        if ( "error" in dataAnswer[API.ENEDIS_RETURN].keys()):
+        #            if ( dataAnswer[API.ENEDIS_RETURN]["error"] == "UNKERROR_TIMEOUT"):
         #                raise error
         return dataAnswer
 

--- a/custom_components/apiEnedis/myCheckData.py
+++ b/custom_components/apiEnedis/myCheckData.py
@@ -1,3 +1,6 @@
+from . import apiconst as API
+
+
 class myCheckData:
     def __init__(self):
         # pas d'init defini
@@ -9,8 +12,8 @@ class myCheckData:
             raise Exception("call", None)
         else:
             tot = 0
-            if "meter_reading" in data.keys():  # meter reading present
-                for x in data["meter_reading"]["interval_reading"]:
+            if API.METER_READING in data.keys():  # meter reading present
+                for x in data[API.METER_READING]["interval_reading"]:
                     tot += int(x["value"])
             return tot
 
@@ -20,8 +23,8 @@ class myCheckData:
             raise Exception("call", None)
         else:
             niemejour = 0
-            if "meter_reading" in data.keys():  # meter reading present
-                for x in reversed(data["meter_reading"]["interval_reading"]):
+            if API.METER_READING in data.keys():  # meter reading present
+                for x in reversed(data[API.METER_READING]["interval_reading"]):
                     niemejour += 1
                     days = {}
                     days["date"] = x["date"]
@@ -34,74 +37,74 @@ class myCheckData:
         if data is None:  # pas de valeur
             return None
         else:
-            if "meter_reading" in data.keys():
-                return int(data["meter_reading"]["interval_reading"][0]["value"])
+            if API.METER_READING in data.keys():
+                return int(data[API.METER_READING]["interval_reading"][0]["value"])
             else:
                 return None
 
     def checkData(self, dataAnswer):
         # new version de la réponse
         # si erreur 500
-        if dataAnswer.get("error_code", 200) == 500:
+        if dataAnswer.get(API.ERROR_CODE, 200) == 500:
             return False
-        if "error_code" in dataAnswer.keys():
+        if API.ERROR_CODE in dataAnswer.keys():
             # point dans le mauvais sens de lecture
-            if dataAnswer["error_code"] == "ADAM-ERR0069":
+            if dataAnswer[API.ERROR_CODE] == "ADAM-ERR0069":
                 return False
             # collecte horaire non activée
-            if dataAnswer["error_code"] == "ADAM-ERR0075":
+            if dataAnswer[API.ERROR_CODE] == "ADAM-ERR0075":
                 return False
             # no_data_found
-            if dataAnswer["error_code"] == "no_data_found":
+            if dataAnswer[API.ERROR_CODE] == "no_data_found":
                 raise Exception(
                     "call",
                     "error",
                     "Collecte de données non activée sur le site enedis.fr",
                 )
             # No consent can be found for this customer and this usage point
-            if dataAnswer["error_code"] in [
+            if dataAnswer[API.ERROR_CODE] in [
                 "ADAM-DC-0008",
                 "ADAM-ERR0069",
                 "UNKERROR_002",
             ]:
                 return False
-            if dataAnswer["error_code"] == "Internal Server error":
+            if dataAnswer[API.ERROR_CODE] == "Internal Server error":
                 # erreur interne enedis
                 raise Exception("call", "error", "UNKERROR_001")
             else:
-                raise Exception("call", "error", dataAnswer["error_code"])
-        if "_error" in dataAnswer.keys():  # a reactiver plus tard !!!
+                raise Exception("call", "error", dataAnswer[API.ERROR_CODE])
+        if "_error" in dataAnswer.keys():  # TODO a reactiver plus tard !!!
             # y a t il une erreur de consentement
-            if dataAnswer["user_alert"]:
+            if dataAnswer[API.USER_ALERT]:
                 raise Exception(
                     "call",
                     "error_user_alert",
-                    dataAnswer["error"],
-                    dataAnswer["description"],
+                    dataAnswer[API.ERROR],
+                    dataAnswer[API.DESCRIPTION],
                 )
-        if "meter_reading" not in dataAnswer.keys():
+        if API.METER_READING not in dataAnswer.keys():
             return False
         return True
 
     def checkDataPeriod(self, dataAnswer):
-        if dataAnswer.get("error_code", 200) == 500:
+        if dataAnswer.get(API.ERROR_CODE, 200) == 500:
             return False
-        if "error_code" in dataAnswer.keys():
+        if API.ERROR_CODE in dataAnswer.keys():
             if (
-                (dataAnswer["error_code"] == "ADAM-ERR0123")
-                or (dataAnswer["error_code"] == "no_data_found")
-                or (dataAnswer["error_code"] == "ADAM-ERR0069")
-                or (dataAnswer["error_code"] == "UNKERROR_002")
+                (dataAnswer[API.ERROR_CODE] == "ADAM-ERR0123")
+                or (dataAnswer[API.ERROR_CODE] == "no_data_found")
+                or (dataAnswer[API.ERROR_CODE] == "ADAM-ERR0069")
+                or (dataAnswer[API.ERROR_CODE] == "UNKERROR_002")
             ):
                 return False
             # collecte horaire non activée
-            if dataAnswer["error_code"] == "ADAM-ERR0075":
+            if dataAnswer[API.ERROR_CODE] == "ADAM-ERR0075":
                 return False
-            if dataAnswer["error_code"] == "Internal Server error":
+            if dataAnswer[API.ERROR_CODE] == "Internal Server error":
                 # erreur interne enedis
                 raise Exception("call", "error", "UNKERROR_001")
             else:
-                raise Exception("call", "error", dataAnswer["error_code"])
-        if "meter_reading" not in dataAnswer.keys():
+                raise Exception("call", "error", dataAnswer[API.ERROR_CODE])
+        if API.METER_READING not in dataAnswer.keys():
             return False
         return True

--- a/custom_components/apiEnedis/myClientEnedis.py
+++ b/custom_components/apiEnedis/myClientEnedis.py
@@ -25,6 +25,7 @@ except ImportError:
     )
     import gitinformation  # type: ignore[no-redef]
 
+from . import apiconst as API
 from . import const
 from .myCall import myCall
 from .myContrat import myContrat
@@ -234,10 +235,10 @@ class myClientEnedis:
                 data = self.getDataJsonValue(clef)
                 # si la date est du timeout, alors on ecrit
                 nePasEcrire = False
-                if "enedis_return" in data:
-                    enedis_return = data["enedis_return"]
-                    if "error" in enedis_return:
-                        nePasEcrire = enedis_return["error"] in (
+                if API.ENEDIS_RETURN in data:
+                    enedis_return = data[API.ENEDIS_RETURN]
+                    if API.ENEDIS_RETURN_ERROR in enedis_return:
+                        nePasEcrire = enedis_return[API.ENEDIS_RETURN_ERROR] in (
                             "UNKERROR_TIMEOUT",
                             "UNAVAILABLE",
                         )
@@ -869,24 +870,26 @@ class myClientEnedis:
         return self._errorLastCall
 
     def getCardErrorLastCall(self):
-        if self._myCalli.getLastAnswer() is None:
+        lastAnswer = self._myCalli.getLastAnswer()
+        if lastAnswer is None:
             return ""
-        if "alert_user" not in self._myCalli.getLastAnswer():
+        if API.ALERT_USER not in lastAnswer:
             return self.getErrorLastCall()
-        if not self._myCalli.getLastAnswer()["alert_user"]:
+        if not lastAnswer[API.ALERT_USER]:
             return ""
         if (
-            "description" in self._myCalli.getLastAnswer()
-            and "tag" in self._myCalli.getLastAnswer()
+            API.DESCRIPTION in lastAnswer
+            and API.TAG in lastAnswer
+            and API.ERROR_CODE in lastAnswer
         ):
             # si erreur autre que mauvais sens de lecture...
-            if self._myCalli.getLastAnswer()["error_code"] == "ADAM-ERR0069":
+            if lastAnswer[API.ERROR_CODE] == "ADAM-ERR0069":
                 return ""
             else:
                 return "{} ({}-{})".format(
-                    self._myCalli.getLastAnswer()["description"],
-                    self._myCalli.getLastAnswer()["error_code"],
-                    self._myCalli.getLastAnswer()["tag"],
+                    lastAnswer[API.DESCRIPTION],
+                    lastAnswer[API.ERROR_CODE],
+                    lastAnswer[API.TAG],
                 )
         else:
             return self.getErrorLastCall()

--- a/custom_components/apiEnedis/myContrat.py
+++ b/custom_components/apiEnedis/myContrat.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+from . import apiconst as API
 
 try:
     from .const import (  # isort:skip
@@ -11,12 +14,11 @@ try:
 
 except ImportError:
     from const import (  # type: ignore[no-redef]
+        __nameMyEnedis__,
         _consommation,
         _production,
-        __nameMyEnedis__,
     )
 
-import logging
 
 log = logging.getLogger(__nameMyEnedis__)
 
@@ -67,14 +69,14 @@ class myContrat:
             return myContrat._NULL_CONTRACT[clef]
 
     def __checkDataContract(self, dataAnswer):
-        if "error_code" in dataAnswer.keys():
-            if dataAnswer["error_code"] == "UNKERROR_001":
+        if API.ERROR_CODE in dataAnswer.keys():
+            if dataAnswer[API.ERROR_CODE] == "UNKERROR_001":
                 return False
             raise Exception("call", "error", dataAnswer)
-        elif dataAnswer.get("error_code", 200) != 200:
-            raise Exception("call", "error", dataAnswer["tag"])
+        elif dataAnswer.get(API.ERROR_CODE, 200) != 200:
+            raise Exception("call", "error", dataAnswer[API.TAG])
         elif dataAnswer.get("error", "") == "token_refresh_401":
-            raise Exception("call", "error", dataAnswer["description"])
+            raise Exception("call", "error", dataAnswer[API.DESCRIPTION])
         return True
 
     def getUsagePointStatus(self):
@@ -142,14 +144,14 @@ class myContrat:
 
     def minCompareDateContract(self, datePeriod):
         minDate = self.getLastActivationDate()
-        if (minDate is not None) and (minDate > "%s" % datePeriod):
+        if (minDate is not None) and (minDate > str(datePeriod)):
             return minDate
         else:
             return datePeriod
 
     def maxCompareDateContract(self, datePeriod):
         dateContract = self.getLastActivationDate()
-        if (dateContract is not None) and (dateContract < "%s" % datePeriod):
+        if (dateContract is not None) and (dateContract < str(datePeriod)):
             return datePeriod
         else:
             return None

--- a/custom_components/apiEnedis/myDataControl.py
+++ b/custom_components/apiEnedis/myDataControl.py
@@ -27,7 +27,7 @@ def okDataControl(
     log.info(
         "--okDataControl / fin : {} / {}".format(dataControl.get("fin", None), dateFin)
     )
-    log.info("--okDataControl / callok : %s " % (dataControl.get("callok", True)))
+    log.info("--okDataControl / callok : %s ", (dataControl.get("callok", True)))
     deb = dataControl.get("deb", None)
     fin = dataControl.get("fin", None)
     callOk = dataControl.get("callok", True)

--- a/custom_components/apiEnedis/myDataEnedis.py
+++ b/custom_components/apiEnedis/myDataEnedis.py
@@ -82,13 +82,11 @@ class myDataEnedis:
             self._dateDeb = dateDeb
             self._dateFin = dateFin
             log.info(
-                "--updateData %s ( du %s au %s ) data:%s--"
-                % (
-                    clefFunction,
-                    dateDeb,
-                    dateFin,
-                    data,
-                )
+                "--updateData %s ( du %s au %s ) data:%s--",
+                clefFunction,
+                dateDeb,
+                dateFin,
+                data,
             )
             self._data = data
             if self._data is None:

--- a/custom_components/apiEnedis/myDataEnedisByDayDetail.py
+++ b/custom_components/apiEnedis/myDataEnedisByDayDetail.py
@@ -122,7 +122,7 @@ class myDataEnedisByDayDetail:
                 self._nbCall = 1
             else:
                 callDone = True
-            log.info("updateData : data %s" % (self._data))
+            log.info("updateData : data %s", self._data)
             if self._multiDays:
                 if self._dateDeb == self._dateFin:
                     self._HC, self._HP = {}, {}

--- a/custom_components/apiEnedis/myDataEnedisMaxPower.py
+++ b/custom_components/apiEnedis/myDataEnedisMaxPower.py
@@ -87,7 +87,7 @@ class myDataEnedisMaxPower:
                 self._nbCall = 1
             else:
                 callDone = True
-            log.info("updateData : data %s" % (self._data))
+            log.info("updateData : data %s", self._data)
             if (callDone) and (myCheckData().checkData(self._data)):
                 self._value = myCheckData().analyseValue(self._data)
                 self._callOk = True
@@ -95,8 +95,8 @@ class myDataEnedisMaxPower:
                 self._value = 0
             self._callOk = callDone
             log.info(f"with update !! {clefFunction} ( du {dateDeb} au {dateFin} )--")
-            log.info("updateData : data %s" % (self._data))
+            log.info("updateData : data %s", (self._data))
         else:
             log.info(f"noupdate !! {clefFunction} ( du {dateDeb} au {dateFin} )--")
-            log.info("no updateData : data %s" % (self._data))
+            log.info("no updateData : data %s", (self._data))
         return self._data

--- a/custom_components/apiEnedis/myDataEnedisProduction.py
+++ b/custom_components/apiEnedis/myDataEnedisProduction.py
@@ -87,7 +87,7 @@ class myDataEnedisProduction:
                 self._nbCall = 1
             else:
                 callDone = True
-            log.info("updateData : data %s" % (self._data))
+            log.info("updateData : data %s", (self._data))
             if (callDone) and (myCheckData().checkData(self._data)):
                 self._value = myCheckData().analyseValue(self._data)
                 self._callOk = True
@@ -95,8 +95,8 @@ class myDataEnedisProduction:
                 self._value = 0
             self._callOk = callDone
             log.info(f"with update !! {clefFunction} ( du {dateDeb} au {dateFin} )--")
-            log.info("updateData : data %s" % (self._data))
+            log.info("updateData : data %s", (self._data))
         else:
             log.info(f"noupdate !! {clefFunction} ( du {dateDeb} au {dateFin} )--")
-            log.info("no updateData : data %s" % (self._data))
+            log.info("no updateData : data %s", (self._data))
         return self._data

--- a/custom_components/apiEnedis/myEnedisSensorCoordinatorEnergy.py
+++ b/custom_components/apiEnedis/myEnedisSensorCoordinatorEnergy.py
@@ -53,22 +53,22 @@ class myEnedisSensorCoordinatorEnergy(CoordinatorEntity, RestoreEntity):
     def unique_id(self):
         "Return a unique_id for this entity."
         if self._typeSensor == _production:
-            name = "myEnedis.energy.%s.production" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.energy.{}.production".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         else:
-            name = "myEnedis.energy.%s" % (self._myDataSensorEnedis.get_PDL_ID())
+            name = f"myEnedis.energy.{self._myDataSensorEnedis.get_PDL_ID()}"
         return name
 
     @property
     def name(self):
         """Return the name of the sensor."""
         if self._typeSensor == _production:
-            name = "myEnedis.energy.%s.production" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.energy.{}.production".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         else:
-            name = "myEnedis.energy.%s" % (self._myDataSensorEnedis.get_PDL_ID())
+            name = f"myEnedis.energy.{self._myDataSensorEnedis.get_PDL_ID()}"
         return name
 
     @property

--- a/custom_components/apiEnedis/myEnedisSensorCoordinatorEnergyDetailHours.py
+++ b/custom_components/apiEnedis/myEnedisSensorCoordinatorEnergyDetailHours.py
@@ -53,22 +53,22 @@ class myEnedisSensorCoordinatorEnergyDetailHours(CoordinatorEntity, RestoreEntit
     def unique_id(self):
         "Return a unique_id for this entity."
         if self._typeSensor == _production:
-            name = "myEnedis.energy.Hours.%s.production" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.energy.Hours.{}.production".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         else:
-            name = "myEnedis.energy.Hours.%s" % (self._myDataSensorEnedis.get_PDL_ID())
+            name = f"myEnedis.energy.Hours.{self._myDataSensorEnedis.get_PDL_ID()}"
         return name
 
     @property
     def name(self):
         """Return the name of the sensor."""
         if self._typeSensor == _production:
-            name = "myEnedis.energy.Hours.%s.production" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.energy.Hours.{}.production".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         else:
-            name = "myEnedis.energy.Hours.%s" % (self._myDataSensorEnedis.get_PDL_ID())
+            name = f"myEnedis.energy.Hours.{self._myDataSensorEnedis.get_PDL_ID()}"
         return name
 
     @property

--- a/custom_components/apiEnedis/myEnedisSensorCoordinatorEnergyDetailHoursCost.py
+++ b/custom_components/apiEnedis/myEnedisSensorCoordinatorEnergyDetailHoursCost.py
@@ -53,12 +53,12 @@ class myEnedisSensorCoordinatorEnergyDetailHoursCost(CoordinatorEntity, RestoreE
     def unique_id(self):
         "Return a unique_id for this entity."
         if self._typeSensor == _production:
-            name = "myEnedis.energy.Hours.cost.%s.production" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.energy.Hours.cost.{}.production".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         else:
-            name = "myEnedis.energy.Hours.cost.%s" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.energy.Hours.cost.{}".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         return name
 
@@ -66,12 +66,12 @@ class myEnedisSensorCoordinatorEnergyDetailHoursCost(CoordinatorEntity, RestoreE
     def name(self):
         """Return the name of the sensor."""
         if self._typeSensor == _production:
-            name = "myEnedis.energy.Hours.cost.%s.production" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.energy.Hours.cost.{}.production".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         else:
-            name = "myEnedis.energy.Hours.cost.%s" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.energy.Hours.cost.{}".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         return name
 

--- a/custom_components/apiEnedis/myEnedisSensorCoordinatorHistory.py
+++ b/custom_components/apiEnedis/myEnedisSensorCoordinatorHistory.py
@@ -50,7 +50,7 @@ class myEnedisSensorCoordinatorHistory(CoordinatorEntity, RestoreEntity):
             interval = 60.0
             _LOGGER.warn(f"{ENTITY_DELAI} non defini pour le sensor")
         self.update = Throttle(timedelta(seconds=interval))(self._update)
-        _LOGGER.info("frequence mise à jour en seconde : %s" % (interval))
+        _LOGGER.info("frequence mise à jour en seconde : %s", (interval))
         self._attributes: dict[str, int | str] = {}
         self._state: str
         self._unit = "kWh"

--- a/custom_components/apiEnedis/myEnedisSensorYesterdayCostCoordinator.py
+++ b/custom_components/apiEnedis/myEnedisSensorYesterdayCostCoordinator.py
@@ -55,12 +55,12 @@ class myEnedisSensorYesterdayCostCoordinator(CoordinatorEntity, RestoreEntity):
     def unique_id(self):
         "Return a unique_id for this entity."
         if self._typeSensor == _production:
-            name = "myEnedis.cost.yesterday.%s.production" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.cost.yesterday.{}.production".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         else:
-            name = "myEnedis.cost.yesterday.%s" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.cost.yesterday.{}".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         return name
 
@@ -68,12 +68,12 @@ class myEnedisSensorYesterdayCostCoordinator(CoordinatorEntity, RestoreEntity):
     def name(self):
         """Return the name of the sensor."""
         if self._typeSensor == _production:
-            name = "myEnedis.cost.yesterday.%s.production" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.cost.yesterday.{}.production".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         else:
-            name = "myEnedis.cost.yesterday.%s" % (
-                self._myDataSensorEnedis.get_PDL_ID()
+            name = "myEnedis.cost.yesterday.{}".format(
+                self._myDataSensorEnedis.get_PDL_ID(),
             )
         return name
 

--- a/custom_components/apiEnedis/sensorEnedis.py
+++ b/custom_components/apiEnedis/sensorEnedis.py
@@ -201,7 +201,7 @@ class manageSensorState:
 
         if data.getTimeLastCall() is not None:
             self._LOGGER.info(
-                "-- ** on va mettre à jour : %s" % data.contract.get_PDL_ID()
+                "-- ** on va mettre à jour : %s", data.contract.get_PDL_ID()
             )
             status["nbCall"] = data.getNbCall()
             status["typeCompteur"] = typeSensor
@@ -261,7 +261,7 @@ class manageSensorState:
                             valeur = -1
                             if clef in last7daysHC.keys():
                                 valeur = last7daysHC[clef]
-                            status["day_%s_HC" % (niemejour)] = valeur
+                            status[f"day_{niemejour}_HC"] = valeur
                         # gestion du cout par jour ....
 
                         niemejour = 0
@@ -511,7 +511,7 @@ class manageSensorState:
             status["errorLastCall"] = data.getCardErrorLastCall()
             status["errorLastCallInterne"] = data.getErrorLastCall()
         self._LOGGER.info("*** SENSOR ***")
-        self._LOGGER.info("status :%s" % status)
-        self._LOGGER.info("state :%s" % state)
+        self._LOGGER.info("status :%s", status)
+        self._LOGGER.info("state :%s", state)
         self._LOGGER.info("*** FIN SENSOR ***")
         return status, state

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,8 @@ exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
-# To work with Black
-max-line-length = 88
+# To work with Black, black does not fix all lengths
+max-line-length = 89
 max-complexity = 18
 show-source = True
 statistics = True


### PR DESCRIPTION
J'ai ajouté la nature de l'exception concernant l'erreur d'écriture pour en avoir plus.

Malheureusement le test n'a pas planté en CI cette fois-ci.

J'ai aussi commencé à mettre des constantes pour les champs de l'API.  Cela évitre des erreurs car l'analyse statique reconnaît des erreurs de constantes, tandis que ce n'est pas le cas pour les erreurs dans les strings.