### PR TITLE
Fix integration for Home Assistant 2024.4+ (renamed forward_entry APIs)

### DIFF
--- a/custom_components/apiEnedis/__init__.py
+++ b/custom_components/apiEnedis/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import traceback
 from datetime import timedelta
+from homeassistant.config_entries import ConfigEntry
 
 try:
     from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -146,24 +147,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         UPDATE_LISTENER: update_listener,
     }
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
-
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, platform)
-                for platform in PLATFORMS
-            ]
-        )
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN][entry.entry_id][UNDO_UPDATE_LISTENER]()
         hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER]()


### PR DESCRIPTION
> **Summary**
> Home Assistant core 2024.4 renamed two helpers in `config_entries`:
>
> * `async_forward_entry_setup`  →  `async_forward_entry_setups`
> * `async_forward_entry_unload` → `async_unload_platforms`
>
> The current apiEnedis code still calls the old methods, which raises
> `AttributeError` and prevents the integration from loading (seen as
> `asyncio.exceptions.CancelledError` in the log).

#### **Changes in this PR**

* `__init__.py`

  * replaced `hass.config_entries.async_forward_entry_setup` with
    `hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)`
  * replaced the unload loop with
    `await hass.config_entries.async_unload_platforms(entry, PLATFORMS)`

No functional logic was modified; only the API calls were updated.

#### **Tested on**

* Home Assistant Core 2025.7.1 / Supervisor 2025.07.1
* Installation method : Home Assistant OS
* Verified that:

  * integration loads without error
  * sensors (`sensor.myenedis_*`) are created and update normally
  * unload / reload of the config entry works as expected

*Thank you for maintaining apiEnedis!*
